### PR TITLE
Support more hash commands

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -76,6 +76,22 @@
 		"command": "convert_sha1"
 	},
 	{
+		"caption": "String Utilities: Calculate SHA224",
+		"command": "convert_sha224"
+	},
+	{
+		"caption": "String Utilities: Calculate SHA256",
+		"command": "convert_sha256"
+	},
+	{
+		"caption": "String Utilities: Calculate SHA384",
+		"command": "convert_sha384"
+	},
+	{
+		"caption": "String Utilities: Calculate SHA512",
+		"command": "convert_sha512"
+	},
+	{
 		"caption": "String Utilities: Convert Unixtime <-> Datetime",
 		"command": "convert_time_format"
 	},

--- a/stringutilities.py
+++ b/stringutilities.py
@@ -25,6 +25,27 @@ if sys.hexversion >= 0x3000000:
         return chr(c)
 
 
+class ConvertSelection(sublime_plugin.TextCommand):
+    """Abstract class to implement a command that modifies the current text
+    select. Subclasses must implement the convert method which accepts the
+    selected text and returns a replacement value."""
+
+    def run(self, edit):
+        for region in self.view.sel():
+            if not region.empty():
+                text = self.view.substr(region).encode(self.enc())
+                self.view.replace(edit, region, self.convert(text))
+
+    def enc(self):
+        if self.view.encoding() == 'Undefined':
+            return self.view.settings().get('default_encoding', 'UTF-8')
+        else:
+            return self.view.encoding()
+
+    def convert(self, text):
+        raise NotImplementedError("Subclass must implement convert")
+
+
 class ConvertTabsToSpacesCommand(sublime_plugin.TextCommand):
     #Convert Tabs To Spaces
     def run(self, edit):

--- a/stringutilities.py
+++ b/stringutilities.py
@@ -12,7 +12,7 @@ import time
 import base64
 import html.entities as htmlentitydefs
 from cgi import escape
-from hashlib import md5,sha1
+from hashlib import md5, sha1, sha224, sha256, sha384, sha512
 from datetime import datetime
 from random import sample, choice, randrange
 import os, socket, urllib
@@ -302,35 +302,35 @@ class UrlEncodeCommand(sublime_plugin.TextCommand):
                 self.view.replace(edit, region, text)
 
 
+class ConvertMd5Command(ConvertSelection):
+    """Calculate the MD5 hash of the selected text"""
+    def convert(self, text):
+        return md5(text).hexdigest()
 
+class ConvertSha1Command(ConvertSelection):
+    """Calculate the SHA1 hash of the selected text"""
+    def convert(self, text):
+        return sha1(text).hexdigest()
 
-class ConvertMd5Command(sublime_plugin.TextCommand):
-    #Calculate MD5 hash
-    def run(self, edit):
-        for region in self.view.sel():
-            if not region.empty():
-                text = self.view.substr(region).encode(self.enc())
-                self.view.replace(edit, region, md5(text).hexdigest())
+class ConvertSha224Command(ConvertSelection):
+    """Calculate the SHA224 hash of the selected text"""
+    def convert(self, text):
+        return sha224(text).hexdigest()
 
-    def enc(self):
-        if self.view.encoding() == 'Undefined':
-            return self.view.settings().get('default_encoding', 'UTF-8')
-        else:
-            return self.view.encoding()
+class ConvertSha256Command(ConvertSelection):
+    """Calculate the SHA256 hash of the selected text"""
+    def convert(self, text):
+        return sha256(text).hexdigest()
 
-class ConvertSha1Command(sublime_plugin.TextCommand):
-    #Calculate SHA1 hash
-    def run(self, edit):
-        for region in self.view.sel():
-            if not region.empty():
-                text = self.view.substr(region).encode(self.enc())
-                self.view.replace(edit, region, sha1(text).hexdigest())
+class ConvertSha384Command(ConvertSelection):
+    """Calculate the SHA384 hash of the selected text"""
+    def convert(self, text):
+        return sha384(text).hexdigest()
 
-    def enc(self):
-        if self.view.encoding() == 'Undefined':
-            return self.view.settings().get('default_encoding', 'UTF-8')
-        else:
-            return self.view.encoding()
+class ConvertSha512Command(ConvertSelection):
+    """Calculate the SHA512 hash of the selected text"""
+    def convert(self, text):
+        return sha512(text).hexdigest()
 
 
 class ConvertTimeFormatCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
String Utilities currently supports calculating the MD5 and SHA1 cryptographic hashes of the currently selected text. This change adds support for all the algorithms supported by Python's `hashlib`.

This also introduces an abstract class `ConvertSelection` to reduce boilerplate in the commands. If you like this approach we could simplify the implementation of many of the existing commands.

Thanks for making String Utilities! I look forward to your feedback on this PR.
