### PR TITLE
Fix context menu not appearing

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -42,7 +42,7 @@
 			{ "command": "string_utilities_int_ip", "caption": "Insert Internal IP" },
 			{ "command": "string_utilities_ext_ip", "caption": "Insert External IP" },
 			{ "caption": "-" },
-			{ "command": "string_utilities_decode_json", "caption": "Pretify JSON String" },
+			{ "command": "string_utilities_decode_json", "caption": "Pretify JSON String" }
 		]
 	},
 	{ "caption" : "-", "id" : "context-convert-end"}


### PR DESCRIPTION
Fixing the following error. I've checked around briefly and haven't found mention of this anywhere - not sure why it's happening to me.

`Unable to parse value: Trailing comma before closing bracket at ~/.config/sublime-text-2/Packages/StringUtilities/Context.sublime-menu:45:2`