### PR TITLE
fix for bug with PascalCase conversion

### DIFF
--- a/stringutilities.py
+++ b/stringutilities.py
@@ -106,7 +106,7 @@ class ConvertPascalUnderscoresCommand(sublime_plugin.TextCommand):
         for region in self.view.sel():
             if not region.empty():
                 text = self.view.substr(region)
-                text = self.toPascalCase(text) if '_' in text and text[0].isupper() else self.toUnderscores(text)
+                text = self.toPascalCase(text) if '_' in text and text[0].islower() else self.toUnderscores(text)
                 self.view.replace(edit, region, text)
 
     def toUnderscores(self, name):


### PR DESCRIPTION
In the existing implementation, converting from underscore to PascalCase requires the first letter to be uppercase, which didn't make sense to me, given that the PascalCase->Underscores conversion leaves the first letter lowercase. This small fix now makes PascalCase<->Underscores a working toggle by changing this condition to require a lowercase first letter, similar to how the camelCase<->Underscores conversion works.

The current implementation of these two converters actually seems to have additional problems, and maybe I'll tackle those soon too. Hopefully I haven't misunderstood anything here about how this function is supposed to work!